### PR TITLE
Added missing ```

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ public let configurationUpdates: AsyncStream<ATProtocolConfiguration?>
         }
     }
 }
+```
 
 ### Testing Approach
 - Swift Testing framework (modern replacement for XCTest)


### PR DESCRIPTION
A code block wasn't properly closed and it messed the layout of the rest of the file.