### PR TITLE
Fix concurrency related build issues

### DIFF
--- a/.github/workflows/icy_sky.yml
+++ b/.github/workflows/icy_sky.yml
@@ -36,6 +36,8 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_26_beta.app
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+      - name: Download iOS 26 Simulator
+        run: xcodebuild -downloadPlatform iOS
       - name: Test Features Package
         run: xcodebuild test -scheme FeaturesTests -destination 'platform=iOS Simulator,name=iPhone 16'
 
@@ -50,6 +52,8 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_26_beta.app
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+      - name: Download iOS 26 Simulator
+        run: xcodebuild -downloadPlatform iOS
       - name: Build IcySky
         run: xcodebuild -scheme IcySky -destination 'platform=iOS Simulator,name=iPhone 16' -configuration "Debug" build
       - name: Share IcySky

--- a/.github/workflows/icy_sky.yml
+++ b/.github/workflows/icy_sky.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_16.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_26_beta.app
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Test Model Package
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_16.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_26_beta.app
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Test Features Package
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_16.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_26_beta.app
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Build IcySky

--- a/App/AppTabsRoot.swift
+++ b/App/AppTabsRoot.swift
@@ -32,6 +32,7 @@ struct AppTabRootView: View {
 }
 
 extension AppTab {
+  @MainActor
   @ViewBuilder
   fileprivate var rootView: some View {
     switch self {

--- a/Packages/Features/Package.swift
+++ b/Packages/Features/Package.swift
@@ -14,7 +14,7 @@ let baseDeps: [PackageDescription.Target.Dependency] = [
 
 let package = Package(
   name: "Features",
-  platforms: [.iOS(.v26), .macOS(.v26)],
+  platforms: [.iOS(.v26), .macOS(.v15)],
   products: [
     .library(name: "FeedUI", targets: ["FeedUI"]),
     .library(name: "PostUI", targets: ["PostUI"]),

--- a/Packages/Features/Tests/DesignSystemTests/HeaderViewTests.swift
+++ b/Packages/Features/Tests/DesignSystemTests/HeaderViewTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Testing
 import ViewInspector
 
+@MainActor
 struct HeaderViewTests {
   @Test func testHeaderViewTitle() throws {
     let title = "TestTitle"

--- a/Packages/Features/Tests/FeedUITests/FeedsListTitleViewTests.swift
+++ b/Packages/Features/Tests/FeedUITests/FeedsListTitleViewTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Testing
 import ViewInspector
 
+@MainActor
 struct FeedsListTitleViewTests {
   @FocusState var isSearchFocused: Bool
   @State var filter: FeedsListFilter = .myFeeds

--- a/Packages/Model/Package.swift
+++ b/Packages/Model/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "Model",
-  platforms: [.iOS(.v26), .macOS(.v26)],
+  platforms: [.iOS(.v26), .macOS(.v15)],
   products: [
     .library(name: "Client", targets: ["Client"]),
     .library(name: "Models", targets: ["Models"]),

--- a/Packages/Model/Tests/AuthTests/AuthTests.swift
+++ b/Packages/Model/Tests/AuthTests/AuthTests.swift
@@ -3,6 +3,13 @@ import Auth
 import Testing
 import Foundation
 
+actor UpdatesCollector<T> {
+  private(set) var items: [T] = []
+  func append(_ item: T) {
+    items.append(item)
+  }
+}
+
 struct AuthTests {
 
   @Test func testLogoutClearsConfigurationAndEmitsNil() async throws {
@@ -55,12 +62,12 @@ struct AuthTests {
   
   @Test func testConfigurationUpdatesStream() async throws {
     let auth = Auth()
-    var updates: [ATProtocolConfiguration?] = []
+    let updates = UpdatesCollector<ATProtocolConfiguration?>()
     
     let task = Task {
       for await config in auth.configurationUpdates {
-        updates.append(config)
-        if updates.count >= 2 { break }
+        await updates.append(config)
+        if await updates.items.count >= 2 { break }
       }
     }
     
@@ -73,7 +80,8 @@ struct AuthTests {
     try await Task.sleep(nanoseconds: 100_000_000) // 100ms
     task.cancel()
     
-    #expect(updates.count == 2)
-    #expect(updates.allSatisfy { $0 == nil })
+    let collectedUpdates = await updates.items
+    #expect(collectedUpdates.count == 2)
+    #expect(collectedUpdates.allSatisfy { $0 == nil })
   }
 }


### PR DESCRIPTION
This pull request updates the project to use Xcode 26 beta in CI workflows, adjusts platform deployment targets for macOS, and improves test reliability and actor-safety in the test suite. The most important changes are grouped below:

**CI/CD Workflow Updates:**

* Updated all CI jobs in `.github/workflows/icy_sky.yml` to use Xcode 26 beta instead of Xcode 16.1, ensuring builds and tests run against the latest Xcode version. [[1]](diffhunk://#diff-5d3d62595b6c1d0850306d752665b66897f35d698b79b979147131297b05018fL22-R22) [[2]](diffhunk://#diff-5d3d62595b6c1d0850306d752665b66897f35d698b79b979147131297b05018fL36-R40) [[3]](diffhunk://#diff-5d3d62595b6c1d0850306d752665b66897f35d698b79b979147131297b05018fL50-R56)
* Added steps to download the iOS 26 Simulator in relevant CI jobs to match the updated Xcode version. [[1]](diffhunk://#diff-5d3d62595b6c1d0850306d752665b66897f35d698b79b979147131297b05018fL36-R40) [[2]](diffhunk://#diff-5d3d62595b6c1d0850306d752665b66897f35d698b79b979147131297b05018fL50-R56)

**Platform Deployment Target Adjustments:**

* Lowered the minimum macOS deployment target from `.v26` to `.v15` in both `Packages/Features/Package.swift` and `Packages/Model/Package.swift`, increasing compatibility. [[1]](diffhunk://#diff-eb0e186367883c9b36ee8bbc643ff1008df955f5e13672fc8001925e083639f6L17-R17) [[2]](diffhunk://#diff-2624917112b1ba6aeafcbcc788a04453e0efeee13eebc7cc6d173fd44ed99056L8-R8)

**Test Improvements and Actor Safety:**

* Introduced an `UpdatesCollector` actor in `AuthTests.swift` to safely collect asynchronous updates, and refactored tests to use this actor for concurrency correctness. [[1]](diffhunk://#diff-5cf94b8eb1cef12a3bafe5bc1343db4788affbce54f3f0222bf46371a72bf936R6-R12) [[2]](diffhunk://#diff-5cf94b8eb1cef12a3bafe5bc1343db4788affbce54f3f0222bf46371a72bf936L58-R70) [[3]](diffhunk://#diff-5cf94b8eb1cef12a3bafe5bc1343db4788affbce54f3f0222bf46371a72bf936L76-R85)
* Added `@MainActor` annotations to test structs and view builders in `HeaderViewTests.swift`, `FeedsListTitleViewTests.swift`, and `AppTabsRoot.swift` to ensure UI-related code runs on the main thread. [[1]](diffhunk://#diff-5d87c2e207bc5ebc832535e8039b9db71e2d7a92c94a610eb2761766e54db307R6) [[2]](diffhunk://#diff-8fab292c5c5f8a61902efb6329dcb8c4a023378b7045889d9524ef6b1eca281aR6) [[3]](diffhunk://#diff-9842b4e59243eaba8044ea2ef08386d6e4829a473f17346fee997af13c18fddeR35)